### PR TITLE
deleted instruction repetition

### DIFF
--- a/chapter2/quantum_operations.py
+++ b/chapter2/quantum_operations.py
@@ -27,6 +27,6 @@ t1_quantum_state = nump.dot(SWAP_quantum_gate, t0_quantum_state)
 print("SWAP Quantum  Gate - T1 Quantum state",t1_quantum_state)
 
 Identity_quantum_gate = nump.eye(2)
-t0_quantum_state = multi_quantum_state(zero_quantum_state, one_quantum_state)
+
 t1_quantum_state = nump.dot(multi_quantum_state(Hadmard_quantum_gate, Identity_quantum_gate), t0_quantum_state)
 print("Multi Quantum State of H Quantum gate and I Quantum gate",t1_quantum_state)

--- a/chapter2/set_operations.py
+++ b/chapter2/set_operations.py
@@ -2,7 +2,7 @@ primes11={3,5,7,11,14};
 
 primes12={3,5,7,11,13,17,19,34}
 
-primes=primes11 & primes12
+primes=primes11 | primes12
 
 print("union of sets", primes11,",",primes12," is")
 print(primes)


### PR DESCRIPTION
Deleted instruction 't0_quantum_state = multi_quantum_state(zero_quantum_state, one_quantum_state)' at line 30 because it was the same as instruction at line 25, although the variable t0_quantum_state is never changed.